### PR TITLE
Move bash scripts to sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
       - name: Install dependencies
         if: env.CI_SKIP == 'false'
         run: |
-          bash ./list-npx-cache.bash
+          bash ./list-npx-cache.sh
           npm ci
-          bash ./list-npx-cache.bash
+          bash ./list-npx-cache.sh
 
       - name: Lint
         if: env.CI_SKIP == 'false'

--- a/list-npx-cache.sh
+++ b/list-npx-cache.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 # NOTE: THere is a discrepancy in the npx cache in npm between 8.4.1 and 8.1.4.
 # There is an additional zx found in the npx cache when compared to the local npx cache using 8.1.4.
 
 NPX_CACHE_DIR="$(npm config get cache)/_npx"
 
-if [[ -d $NPX_CACHE_DIR ]]; then
+if [ -d "$NPX_CACHE_DIR" ]; then
   FILES=$(find $NPX_CACHE_DIR -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
   # FILES=$(find $NPX_CACHE_DIR -type f | grep -v 'node_modules')
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rm -rf .*cache *.log .swc/ coverage/ dist/ logs/",
-    "postinstall": "bash postinstall.bash",
+    "postinstall": "sh postinstall.sh",
     "lint": "eslint src --ext .js,.ts",
     "lint:build": "npm run lint -- --config .build.eslintrc.json",
     "lint:commit": "npm x -y -- commitlint@latest --edit",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 npx -y -- zx@latest ./postinstall.mjs


### PR DESCRIPTION
Hello, first of all, great work on the project 😄  

So, onto the PR:

## Issue

We use this package in an application that is running Node in an Alpine Linux container where there is no `bash`, only `sh` is available. 

## Proposed solution

Changing shell scripts to be compatible with `sh`, which will make it compatible with environments where `bash` is not available, such as Alpine Linux.

I noticed the use of bash was in only two scripts. Aside from renaming the scripts and references from `*.bash` to `*.sh`, there was only one code change that was needed, in the conditional in the `list-npx-cache` script the test (`[[`) operator had to be changed to `[` to be compatible with `sh`.

Let me know if these changes are acceptable so we can upgrade to the latest release of the project.

Thanks, have a great week!